### PR TITLE
ホームとヘッダーの CTA を整理

### DIFF
--- a/app/company/page.tsx
+++ b/app/company/page.tsx
@@ -264,7 +264,7 @@ export default function CompanyPage() {
                 href={CONTACT_FORM_URL}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center gap-2 rounded-md bg-primary px-6 py-3 text-sm font-bold text-primary-foreground shadow-sm transition-colors hover:bg-primary/90"
+                className="inline-flex items-center gap-2 rounded-md bg-brand-contact px-6 py-3 text-sm font-bold text-white shadow-sm transition-colors hover:bg-[#4cae50]"
               >
                 お問い合わせフォーム
                 <ArrowRight className="size-4" />

--- a/app/components/Backup.tsx
+++ b/app/components/Backup.tsx
@@ -5,35 +5,43 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 const cards = [
   {
-    href: "/overview#system-support",
-    src: "/images/backup_system.png",
-    alt: "経理システムの導入支援",
-    title: "経理システムの導入支援",
-  },
-  {
     href: "/overview#business-support",
     src: "/images/backup_ec.png",
     alt: "経理支援アイコン",
     title: "経理支援",
+    number: "01",
+  },
+  {
+    href: "/overview#system-support",
+    src: "/images/backup_system.png",
+    alt: "経理システム導入支援アイコン",
+    title: "経理システム導入支援",
+    number: "02",
   },
   {
     href: "/overview#msa-support",
     src: "/images/MAS.png",
-    alt: "MAS",
+    alt: "MAS アイコン",
     title: "経営アドバイザリーサービス",
+    number: "03",
   },
 ] as const;
 
 export default function Backup() {
   return (
     <section className="bg-background px-5 py-14 md:py-20">
-      <div className="mx-auto max-w-6xl text-center">
-        <h2 className="mb-3 text-3xl font-bold tracking-wide text-brand-success md:text-4xl">
-          事 業 概 要
-        </h2>
-        <p className="mb-10 text-base text-muted-foreground md:text-lg">
-          我々は下記サービスを導入支援いたします
-        </p>
+      <div className="mx-auto max-w-6xl">
+        <div className="text-center">
+          <p className="text-sm font-semibold tracking-[0.3em] text-brand-accent uppercase">
+            Our Services
+          </p>
+          <h2 className="mt-3 mb-3 text-3xl font-bold tracking-wide text-brand-success md:text-4xl">
+            事 業 概 要
+          </h2>
+          <p className="mb-10 text-base text-muted-foreground md:text-lg">
+            Ic-Growth が提供する 3 つのサービス
+          </p>
+        </div>
         <div className="grid gap-6 md:grid-cols-3 md:gap-8">
           {cards.map((card) => (
             <Link
@@ -42,22 +50,25 @@ export default function Backup() {
               className="group block focus-visible:outline-none"
             >
               <Card className="h-full transition-all duration-300 group-hover:-translate-y-1.5 group-hover:shadow-xl group-focus-visible:ring-3 group-focus-visible:ring-primary/40">
-                <CardHeader className="items-center pt-2">
-                  <div className="flex justify-center">
+                <CardHeader className="pt-6">
+                  <div className="flex flex-col items-center gap-3">
                     <Image
                       src={card.src}
                       alt={card.alt}
                       width={100}
                       height={100}
-                      className="h-24 w-24 object-contain"
+                      className="h-20 w-20 object-contain md:h-24 md:w-24"
                     />
+                    <span className="text-xs font-semibold tracking-widest text-brand-accent uppercase">
+                      Service {card.number}
+                    </span>
                   </div>
                 </CardHeader>
-                <CardContent className="pb-6">
-                  <CardTitle className="text-lg text-foreground md:text-xl">
+                <CardContent className="pb-6 text-center">
+                  <CardTitle className="mb-3 text-base font-bold text-foreground md:text-lg">
                     {card.title}
                   </CardTitle>
-                  <span className="mt-3 inline-flex items-center gap-1 text-sm text-primary">
+                  <span className="inline-flex items-center gap-1 text-sm text-primary">
                     詳しく見る
                     <ArrowRight className="size-4 transition-transform group-hover:translate-x-1" />
                   </span>

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -19,7 +19,7 @@ const navLinks = [
 ] as const;
 
 const ctaClass =
-  "inline-flex h-10 items-center justify-center rounded-md bg-[#5fc061] px-5 text-sm font-bold text-white shadow-sm transition-colors hover:bg-[#4cae50] focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-[#5fc061]/40";
+  "inline-flex h-10 items-center justify-center rounded-md bg-brand-contact px-5 text-sm font-bold text-white shadow-sm transition-colors hover:bg-[#4cae50] focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-brand-contact/40";
 
 export default function Header() {
   return (

--- a/app/components/SectionComponent1.tsx
+++ b/app/components/SectionComponent1.tsx
@@ -1,4 +1,9 @@
 import Image from "next/image";
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+
+const CONTACT_FORM_URL =
+  "https://docs.google.com/forms/d/e/1FAIpQLScEXuDiU9GfCsL2Q4nmK9En8xLd8UzVYR6B95K9IKwNAL6GTQ/viewform";
 
 export default function SectionComponent1() {
   return (

--- a/app/globals.css
+++ b/app/globals.css
@@ -9,6 +9,7 @@
   --color-brand-dark: #0b1736;
   --color-brand-accent: #f5a623;
   --color-brand-success: #215126;
+  --color-brand-contact: #5fc061;
   --font-sans:
     "Hiragino Kaku Gothic ProN", "Yu Gothic", "Meiryo", system-ui, sans-serif;
 }

--- a/app/overview/page.tsx
+++ b/app/overview/page.tsx
@@ -220,7 +220,7 @@ export default function OverviewPage() {
               href={CONTACT_FORM_URL}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 rounded-md bg-primary px-6 py-3 text-sm font-bold text-primary-foreground shadow-sm transition-colors hover:bg-primary/90"
+              className="inline-flex items-center gap-2 rounded-md bg-brand-contact px-6 py-3 text-sm font-bold text-white shadow-sm transition-colors hover:bg-[#4cae50]"
             >
               お問い合わせフォーム
               <ArrowRight className="size-4" />

--- a/docs/shadcn-ui.md
+++ b/docs/shadcn-ui.md
@@ -167,6 +167,42 @@ npm run build       # static export 成功
 npx react-doctor@latest . --score   # 99/100 を baseline として維持
 ```
 
+## 後続の改修ログ
+
+shadcn/ui 初期導入のあとに行った継続改修。
+
+### Typography（feature/typography-and-accent）
+
+- 見出し用フォントとして **Zen Kaku Gothic New** を `next/font/google` 経由で導入
+  （weight 500/700/900、`--font-zen-kaku` 変数として `<html>` にバインド）
+- `globals.css` の `--font-heading` を Zen Kaku に紐付け、`@layer base` で `h1/h2/h3` に自動適用
+- 本文は OS 既定の Hiragino / Yu Gothic スタックのまま（軽量重視）
+
+### アクセントカラーの導入（同上）
+
+- `:root` に `--accent: #f5a623` を残しつつ、実 UI で eyebrow ラベル / 小区切り Separator に投入
+  - `Accounting Transformation` / `Service 0X` / `Our Services` / `Case 0X` などの上付きラベル
+  - 各セクション h2 直下の `Separator`（`max-w-12 bg-brand-accent`）
+- 「青支配 + 朱の差し色」の構図を採用。CTA・カード強調は青のまま
+
+### ハイドレーション・カスケードの落とし穴
+
+- `globals.css` のトップレベルにあった `a { color: inherit; }` がアンレイヤーで Tailwind ユーティリティを上書きしていた
+  → `@layer base` 内に閉じ込めてユーティリティ優先に戻した
+- Server Component 内の `new Date().getFullYear()` は React Doctor がハイドレーション警告を出すため、モジュールトップで定数化（`const COPYRIGHT_YEAR = new Date().getFullYear();`）
+
+### ページ構造の刷新（feature/typography-and-accent / feature/home-and-header-polish）
+
+- `/company`: 「8 行のテーブル単発」を解消し、Hero / 基本情報（dl）/ サービス4カテゴリ Card グリッド / Access + Map iframe + CTA の 4 セクション構成へ
+- `/overview`: 1 列箇条書き + 不揃いな見出し階層を解消し、ヒーロー / 各サービス（左: 番号 + h2 + lede / 右: 特徴ドット箇条書き）/ MAS の Case 01・02 サブカード / 末尾 CTA の構成へ
+- `/`（ホーム）: ヒーロー (`SectionComponent1`) に「サービスを見る / お問い合わせ」の二段 CTA を追加。`Backup` の 3 カードを `/overview` ヒーローと同じ「icon + Service 番号 + 詳しく見る →」パターンに統一
+- お問い合わせ系 CTA（Header / `/overview` 末尾 / `/company` 末尾）はブランドのコンタクト用イメージカラー `#5fc061` で統一。`globals.css` に `--color-brand-contact` トークンを追加し、`bg-brand-contact` で参照する。電話発信用 `Consult` のアイコン背景・電話番号テキストにも同色を使用
+
+### ブランチ運用の自動化
+
+- `.claude/hooks/branch-guard.sh` を新設し、`develop` / `prod` / `main` での `Edit` / `Write` を PreToolUse で `exit 2` ブロック
+- `.claude/settings.json` の `PreToolUse: Write|Edit` matcher 先頭に登録
+
 ## 参考リンク
 
 - shadcn/ui: <https://ui.shadcn.com/>


### PR DESCRIPTION
- Header / /overview 末尾 / /company 末尾の「お問い合わせ」を緑で統一 （--color-brand-contact トークンを globals.css に追加）
- Backup を Service N eyebrow + /overview と同順序に刷新 （PNG イラストは維持）
- SectionComponent1 に「サービスを見る / お問い合わせ」二段 CTA を追加
- docs/shadcn-ui.md に変更ログ追記