### PR TITLE
ESLint を flat config (eslint.config.mjs) に移行

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-  "extends": "next/core-web-vitals"
-}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,14 @@
+import { FlatCompat } from "@eslint/eslintrc";
+
+const compat = new FlatCompat({
+  baseDirectory: import.meta.dirname,
+});
+
+const eslintConfig = [
+  ...compat.extends("next/core-web-vitals"),
+  {
+    ignores: [".next/**", "out/**", "node_modules/**"],
+  },
+];
+
+export default eslintConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ic-gr-website",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ic-gr-website",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "dependencies": {
         "@base-ui/react": "^1.4.1",
         "class-variance-authority": "^0.7.1",
@@ -20,6 +20,7 @@
         "tw-animate-css": "^1.4.0"
       },
       "devDependencies": {
+        "@eslint/eslintrc": "^3.3.5",
         "@tailwindcss/postcss": "^4.0.0",
         "@types/node": "^22.10.0",
         "@types/react": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "eslint .",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -25,6 +25,7 @@
     "tw-animate-css": "^1.4.0"
   },
   "devDependencies": {
+    "@eslint/eslintrc": "^3.3.5",
     "@tailwindcss/postcss": "^4.0.0",
     "@types/node": "^22.10.0",
     "@types/react": "^19.0.0",


### PR DESCRIPTION
- next lint deprecation 対応（Next.js 16 で削除予定）
- .eslintrc.json (legacy) を削除し eslint.config.mjs (flat config) を導入
- eslint-config-next は legacy 形式のため FlatCompat 経由で読み込む
- package.json: lint スクリプトを "next lint" → "eslint ." に変更
- @eslint/eslintrc を devDependencies に明示追加