### PR TITLE
Release: ホーム CTA 整理 / 404 ページ / ESLint 移行

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-  "extends": "next/core-web-vitals"
-}

--- a/app/company/page.tsx
+++ b/app/company/page.tsx
@@ -264,7 +264,7 @@ export default function CompanyPage() {
                 href={CONTACT_FORM_URL}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center gap-2 rounded-md bg-primary px-6 py-3 text-sm font-bold text-primary-foreground shadow-sm transition-colors hover:bg-primary/90"
+                className="inline-flex items-center gap-2 rounded-md bg-brand-contact px-6 py-3 text-sm font-bold text-white shadow-sm transition-colors hover:bg-[#4cae50]"
               >
                 お問い合わせフォーム
                 <ArrowRight className="size-4" />

--- a/app/components/Backup.tsx
+++ b/app/components/Backup.tsx
@@ -5,35 +5,43 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 const cards = [
   {
-    href: "/overview#system-support",
-    src: "/images/backup_system.png",
-    alt: "経理システムの導入支援",
-    title: "経理システムの導入支援",
-  },
-  {
     href: "/overview#business-support",
     src: "/images/backup_ec.png",
     alt: "経理支援アイコン",
     title: "経理支援",
+    number: "01",
+  },
+  {
+    href: "/overview#system-support",
+    src: "/images/backup_system.png",
+    alt: "経理システム導入支援アイコン",
+    title: "経理システム導入支援",
+    number: "02",
   },
   {
     href: "/overview#msa-support",
     src: "/images/MAS.png",
-    alt: "MAS",
+    alt: "MAS アイコン",
     title: "経営アドバイザリーサービス",
+    number: "03",
   },
 ] as const;
 
 export default function Backup() {
   return (
     <section className="bg-background px-5 py-14 md:py-20">
-      <div className="mx-auto max-w-6xl text-center">
-        <h2 className="mb-3 text-3xl font-bold tracking-wide text-brand-success md:text-4xl">
-          事 業 概 要
-        </h2>
-        <p className="mb-10 text-base text-muted-foreground md:text-lg">
-          我々は下記サービスを導入支援いたします
-        </p>
+      <div className="mx-auto max-w-6xl">
+        <div className="text-center">
+          <p className="text-sm font-semibold tracking-[0.3em] text-brand-accent uppercase">
+            Our Services
+          </p>
+          <h2 className="mt-3 mb-3 text-3xl font-bold tracking-wide text-brand-success md:text-4xl">
+            事 業 概 要
+          </h2>
+          <p className="mb-10 text-base text-muted-foreground md:text-lg">
+            Ic-Growth が提供する 3 つのサービス
+          </p>
+        </div>
         <div className="grid gap-6 md:grid-cols-3 md:gap-8">
           {cards.map((card) => (
             <Link
@@ -42,22 +50,25 @@ export default function Backup() {
               className="group block focus-visible:outline-none"
             >
               <Card className="h-full transition-all duration-300 group-hover:-translate-y-1.5 group-hover:shadow-xl group-focus-visible:ring-3 group-focus-visible:ring-primary/40">
-                <CardHeader className="items-center pt-2">
-                  <div className="flex justify-center">
+                <CardHeader className="pt-6">
+                  <div className="flex flex-col items-center gap-3">
                     <Image
                       src={card.src}
                       alt={card.alt}
                       width={100}
                       height={100}
-                      className="h-24 w-24 object-contain"
+                      className="h-20 w-20 object-contain md:h-24 md:w-24"
                     />
+                    <span className="text-xs font-semibold tracking-widest text-brand-accent uppercase">
+                      Service {card.number}
+                    </span>
                   </div>
                 </CardHeader>
-                <CardContent className="pb-6">
-                  <CardTitle className="text-lg text-foreground md:text-xl">
+                <CardContent className="pb-6 text-center">
+                  <CardTitle className="mb-3 text-base font-bold text-foreground md:text-lg">
                     {card.title}
                   </CardTitle>
-                  <span className="mt-3 inline-flex items-center gap-1 text-sm text-primary">
+                  <span className="inline-flex items-center gap-1 text-sm text-primary">
                     詳しく見る
                     <ArrowRight className="size-4 transition-transform group-hover:translate-x-1" />
                   </span>

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -19,7 +19,7 @@ const navLinks = [
 ] as const;
 
 const ctaClass =
-  "inline-flex h-10 items-center justify-center rounded-md bg-[#5fc061] px-5 text-sm font-bold text-white shadow-sm transition-colors hover:bg-[#4cae50] focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-[#5fc061]/40";
+  "inline-flex h-10 items-center justify-center rounded-md bg-brand-contact px-5 text-sm font-bold text-white shadow-sm transition-colors hover:bg-[#4cae50] focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-brand-contact/40";
 
 export default function Header() {
   return (

--- a/app/components/SectionComponent1.tsx
+++ b/app/components/SectionComponent1.tsx
@@ -1,4 +1,9 @@
 import Image from "next/image";
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+
+const CONTACT_FORM_URL =
+  "https://docs.google.com/forms/d/e/1FAIpQLScEXuDiU9GfCsL2Q4nmK9En8xLd8UzVYR6B95K9IKwNAL6GTQ/viewform";
 
 export default function SectionComponent1() {
   return (

--- a/app/globals.css
+++ b/app/globals.css
@@ -9,6 +9,7 @@
   --color-brand-dark: #0b1736;
   --color-brand-accent: #f5a623;
   --color-brand-success: #215126;
+  --color-brand-contact: #5fc061;
   --font-sans:
     "Hiragino Kaku Gothic ProN", "Yu Gothic", "Meiryo", system-ui, sans-serif;
 }

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,69 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowRight, Home } from "lucide-react";
+
+export const metadata: Metadata = {
+  title: "ページが見つかりません",
+  description:
+    "お探しのページは見つかりませんでした。Ic-Growth コーポレートサイトのホームへ戻るか、各ページをご覧ください。",
+};
+
+const CONTACT_FORM_URL =
+  "https://docs.google.com/forms/d/e/1FAIpQLScEXuDiU9GfCsL2Q4nmK9En8xLd8UzVYR6B95K9IKwNAL6GTQ/viewform";
+
+const quickLinks = [
+  { href: "/overview", label: "事業概要" },
+  { href: "/company", label: "会社概要" },
+] as const;
+
+export default function NotFound() {
+  return (
+    <section className="bg-gradient-to-b from-muted to-background px-5 py-20 md:py-28">
+      <div className="mx-auto max-w-2xl text-center">
+        <p className="text-sm font-semibold tracking-[0.3em] text-brand-accent uppercase">
+          Error 404
+        </p>
+        <h1 className="mt-6 text-7xl leading-none font-bold tracking-tight text-brand-success md:text-8xl">
+          404
+        </h1>
+        <p className="mt-6 text-lg font-bold text-foreground md:text-xl">
+          ページが見つかりません
+        </p>
+        <p className="mt-3 leading-loose text-muted-foreground">
+          お探しのページは移動または削除された可能性があります。
+          <br />
+          下記からご希望の内容をお探しください。
+        </p>
+        <div className="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
+          <Link
+            href="/"
+            className="inline-flex items-center gap-2 rounded-md bg-primary px-6 py-3 text-sm font-bold text-primary-foreground shadow-sm transition-colors hover:bg-primary/90"
+          >
+            <Home className="size-4" />
+            ホームへ戻る
+          </Link>
+          <a
+            href={CONTACT_FORM_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 rounded-md bg-brand-contact px-6 py-3 text-sm font-bold text-white shadow-sm transition-colors hover:bg-[#4cae50]"
+          >
+            お問い合わせ
+            <ArrowRight className="size-4" />
+          </a>
+        </div>
+        <div className="mt-12 flex items-center justify-center gap-6 text-sm">
+          {quickLinks.map((link) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              className="font-bold text-foreground transition-colors hover:text-primary"
+            >
+              {link.label}
+            </Link>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/app/overview/page.tsx
+++ b/app/overview/page.tsx
@@ -220,7 +220,7 @@ export default function OverviewPage() {
               href={CONTACT_FORM_URL}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 rounded-md bg-primary px-6 py-3 text-sm font-bold text-primary-foreground shadow-sm transition-colors hover:bg-primary/90"
+              className="inline-flex items-center gap-2 rounded-md bg-brand-contact px-6 py-3 text-sm font-bold text-white shadow-sm transition-colors hover:bg-[#4cae50]"
             >
               お問い合わせフォーム
               <ArrowRight className="size-4" />

--- a/docs/shadcn-ui.md
+++ b/docs/shadcn-ui.md
@@ -167,6 +167,42 @@ npm run build       # static export 成功
 npx react-doctor@latest . --score   # 99/100 を baseline として維持
 ```
 
+## 後続の改修ログ
+
+shadcn/ui 初期導入のあとに行った継続改修。
+
+### Typography（feature/typography-and-accent）
+
+- 見出し用フォントとして **Zen Kaku Gothic New** を `next/font/google` 経由で導入
+  （weight 500/700/900、`--font-zen-kaku` 変数として `<html>` にバインド）
+- `globals.css` の `--font-heading` を Zen Kaku に紐付け、`@layer base` で `h1/h2/h3` に自動適用
+- 本文は OS 既定の Hiragino / Yu Gothic スタックのまま（軽量重視）
+
+### アクセントカラーの導入（同上）
+
+- `:root` に `--accent: #f5a623` を残しつつ、実 UI で eyebrow ラベル / 小区切り Separator に投入
+  - `Accounting Transformation` / `Service 0X` / `Our Services` / `Case 0X` などの上付きラベル
+  - 各セクション h2 直下の `Separator`（`max-w-12 bg-brand-accent`）
+- 「青支配 + 朱の差し色」の構図を採用。CTA・カード強調は青のまま
+
+### ハイドレーション・カスケードの落とし穴
+
+- `globals.css` のトップレベルにあった `a { color: inherit; }` がアンレイヤーで Tailwind ユーティリティを上書きしていた
+  → `@layer base` 内に閉じ込めてユーティリティ優先に戻した
+- Server Component 内の `new Date().getFullYear()` は React Doctor がハイドレーション警告を出すため、モジュールトップで定数化（`const COPYRIGHT_YEAR = new Date().getFullYear();`）
+
+### ページ構造の刷新（feature/typography-and-accent / feature/home-and-header-polish）
+
+- `/company`: 「8 行のテーブル単発」を解消し、Hero / 基本情報（dl）/ サービス4カテゴリ Card グリッド / Access + Map iframe + CTA の 4 セクション構成へ
+- `/overview`: 1 列箇条書き + 不揃いな見出し階層を解消し、ヒーロー / 各サービス（左: 番号 + h2 + lede / 右: 特徴ドット箇条書き）/ MAS の Case 01・02 サブカード / 末尾 CTA の構成へ
+- `/`（ホーム）: ヒーロー (`SectionComponent1`) に「サービスを見る / お問い合わせ」の二段 CTA を追加。`Backup` の 3 カードを `/overview` ヒーローと同じ「icon + Service 番号 + 詳しく見る →」パターンに統一
+- お問い合わせ系 CTA（Header / `/overview` 末尾 / `/company` 末尾）はブランドのコンタクト用イメージカラー `#5fc061` で統一。`globals.css` に `--color-brand-contact` トークンを追加し、`bg-brand-contact` で参照する。電話発信用 `Consult` のアイコン背景・電話番号テキストにも同色を使用
+
+### ブランチ運用の自動化
+
+- `.claude/hooks/branch-guard.sh` を新設し、`develop` / `prod` / `main` での `Edit` / `Write` を PreToolUse で `exit 2` ブロック
+- `.claude/settings.json` の `PreToolUse: Write|Edit` matcher 先頭に登録
+
 ## 参考リンク
 
 - shadcn/ui: <https://ui.shadcn.com/>

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,14 @@
+import { FlatCompat } from "@eslint/eslintrc";
+
+const compat = new FlatCompat({
+  baseDirectory: import.meta.dirname,
+});
+
+const eslintConfig = [
+  ...compat.extends("next/core-web-vitals"),
+  {
+    ignores: [".next/**", "out/**", "node_modules/**"],
+  },
+];
+
+export default eslintConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ic-gr-website",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ic-gr-website",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "dependencies": {
         "@base-ui/react": "^1.4.1",
         "class-variance-authority": "^0.7.1",
@@ -20,6 +20,7 @@
         "tw-animate-css": "^1.4.0"
       },
       "devDependencies": {
+        "@eslint/eslintrc": "^3.3.5",
         "@tailwindcss/postcss": "^4.0.0",
         "@types/node": "^22.10.0",
         "@types/react": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "eslint .",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -25,6 +25,7 @@
     "tw-animate-css": "^1.4.0"
   },
   "devDependencies": {
+    "@eslint/eslintrc": "^3.3.5",
     "@tailwindcss/postcss": "^4.0.0",
     "@types/node": "^22.10.0",
     "@types/react": "^19.0.0",


### PR DESCRIPTION
## リリース内容

  shadcn/ui + Tailwind v4 ベースの改修フェーズ第二弾。

  ### #29 ホームとヘッダーの CTA を整理
  - お問い合わせ系 CTA（Header / `/overview` 末尾 / `/company` 末尾）をブランドのコンタクト用緑 `#5fc061`
  に統一し、`--color-brand-contact` トークン化
  - Backup の 3 カードを `/overview` と順序整合（経理支援 → システム導入 → MAS）し、Service N eyebrow + 「詳しく見る
  →」構造に
  - ホーム ヒーロー (`SectionComponent1`) に「サービスを見る」「お問い合わせ」二段 CTA を追加

  ### #30 404 ページのデザイン追加
  - `app/not-found.tsx` を新設し、ヒーロー型レイアウト（Error 404 eyebrow / 大きな 404 /
  「ホームへ戻る」+「お問い合わせ」CTA）
  - `/overview` `/company` へのクイックリンクも併設
  - 静的エクスポートで `out/404.html` として書き出し

  ### #31 ESLint flat config 移行
  - `next lint` deprecation 対応（Next.js 16 で削除予定）
  - `.eslintrc.json` (legacy) → `eslint.config.mjs` (flat config)
  - `eslint-config-next` は legacy 形式のため `FlatCompat` 経由で読み込み
  - `npm run lint` を `next lint` → `eslint .` に切り替え

  ## デプロイ前検証

  - [x] `npm ci`
  - [x] `npm run lint`
  - [x] `npm run typecheck`
  - [x] `npm run build`
  - [x] `out/` 配下に各ページ `index.html` + `404.html` 出力確認
  - [x] CloudFront Function (`infra/cloudfront/url-rewrite.js`) に変更なし → AWS 側操作不要
  - [x] React Doctor スコア 99/100 維持

  ## デプロイ後の確認

  - [x] https://www.ic-gr.net/ がリロードして表示される
  - [x] `/overview`, `/company`, `/privacy` 直リンクが 200
  - [x] 存在しないパス（例 `/foo`）で 404 ページが表示される
  - [x] Header の「お問い合わせ」ボタンが緑（`#5fc061`）
  - [x] ホームのヒーロー 二段 CTA（「サービスを見る」「お問い合わせ」）がクリック可能

  ## ロールバック手順

  万一問題があれば prod を 1 コミット revert して push すれば前バージョンに戻る:

  \`\`\`bash
  git checkout prod
  git pull --ff-only origin prod
  git revert -m 1 HEAD --no-edit
  git push origin prod
  \`\`\`